### PR TITLE
Add wallet commands

### DIFF
--- a/src/main/java/org/terasology/economy/WalletCommands.java
+++ b/src/main/java/org/terasology/economy/WalletCommands.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.economy;
+
+import org.terasology.economy.events.UpdateWalletEvent;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.logic.console.commandSystem.annotations.Command;
+import org.terasology.logic.console.commandSystem.annotations.CommandParam;
+import org.terasology.logic.permission.PermissionManager;
+import org.terasology.logic.players.LocalPlayer;
+import org.terasology.registry.In;
+
+@RegisterSystem
+public class WalletCommands extends BaseComponentSystem {
+
+    @In
+    private LocalPlayer localPlayer;
+
+    @Command(shortDescription = "Add money to your wallet", requiredPermission = PermissionManager.CHEAT_PERMISSION)
+    public String giveMoney(@CommandParam(value = "0") int amount) {
+        localPlayer.getCharacterEntity().send(new UpdateWalletEvent(amount));
+        return "Gave " + amount + " to player.";
+    }
+}

--- a/src/main/java/org/terasology/economy/WalletCommands.java
+++ b/src/main/java/org/terasology/economy/WalletCommands.java
@@ -24,6 +24,9 @@ import org.terasology.logic.permission.PermissionManager;
 import org.terasology.logic.players.LocalPlayer;
 import org.terasology.registry.In;
 
+/**
+ * Adds some commands to change the amount in a player's wallet
+ */
 @RegisterSystem
 public class WalletCommands extends BaseComponentSystem {
 

--- a/src/main/java/org/terasology/economy/systems/WalletSystem.java
+++ b/src/main/java/org/terasology/economy/systems/WalletSystem.java
@@ -74,6 +74,11 @@ public class WalletSystem extends BaseComponentSystem {
         walletHud.setLabelText(component.amount);
     }
 
+    /**
+     * Checks if the requested transaction is valid depending on the balance in the player's wallet
+     * @param delta: the change in the wallet after the transaction
+     * @return true if the wallet balance isn't negative after the transaction
+     */
     public boolean isValidTransaction(int delta) {
         int balance = walletEntity.getComponent(CurrencyStorageComponent.class).amount;
         return (balance + delta >= 0);

--- a/src/main/java/org/terasology/economy/ui/WalletHud.java
+++ b/src/main/java/org/terasology/economy/ui/WalletHud.java
@@ -20,10 +20,10 @@ import org.terasology.registry.In;
 import org.terasology.rendering.nui.layers.hud.CoreHudWidget;
 import org.terasology.rendering.nui.widgets.UILabel;
 
+/**
+ * The UI class for the wallet HUD
+ */
 public class WalletHud extends CoreHudWidget {
-
-    @In
-    private LocalPlayer localPlayer;
 
     private UILabel label;
 

--- a/src/main/java/org/terasology/economy/ui/WalletHud.java
+++ b/src/main/java/org/terasology/economy/ui/WalletHud.java
@@ -15,8 +15,6 @@
  */
 package org.terasology.economy.ui;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.terasology.economy.components.CurrencyStorageComponent;
 import org.terasology.economy.systems.WalletSystem;
 import org.terasology.logic.players.LocalPlayer;
@@ -30,12 +28,7 @@ public class WalletHud extends CoreHudWidget {
     @In
     private LocalPlayer localPlayer;
 
-    @In
-    private WalletSystem walletSystem;
-
     private UILabel label;
-
-    private Logger logger = LoggerFactory.getLogger(WalletHud.class);
 
     @Override
     public void initialise() {
@@ -45,12 +38,16 @@ public class WalletHud extends CoreHudWidget {
     @Override
     public void onOpened() {
         super.onOpened();
-        CurrencyStorageComponent component = walletSystem.wallet.getComponent(CurrencyStorageComponent.class);
         if (label != null) {
             label.bindText(new ReadOnlyBinding<String>() {
                 @Override
                 public String get() {
-                    return String.valueOf(component.amount);
+                    CurrencyStorageComponent component = localPlayer.getCharacterEntity().getComponent(CurrencyStorageComponent.class);
+                    if (component != null) {
+                        return String.valueOf(component.amount);
+                    } else {
+                        return "0";
+                    }
                 }
             });
         }

--- a/src/main/java/org/terasology/economy/ui/WalletHud.java
+++ b/src/main/java/org/terasology/economy/ui/WalletHud.java
@@ -15,11 +15,8 @@
  */
 package org.terasology.economy.ui;
 
-import org.terasology.economy.components.CurrencyStorageComponent;
-import org.terasology.economy.systems.WalletSystem;
 import org.terasology.logic.players.LocalPlayer;
 import org.terasology.registry.In;
-import org.terasology.rendering.nui.databinding.ReadOnlyBinding;
 import org.terasology.rendering.nui.layers.hud.CoreHudWidget;
 import org.terasology.rendering.nui.widgets.UILabel;
 
@@ -33,23 +30,10 @@ public class WalletHud extends CoreHudWidget {
     @Override
     public void initialise() {
         label = find("walletInfoLabel", UILabel.class);
+        label.setText("0");
     }
 
-    @Override
-    public void onOpened() {
-        super.onOpened();
-        if (label != null) {
-            label.bindText(new ReadOnlyBinding<String>() {
-                @Override
-                public String get() {
-                    CurrencyStorageComponent component = localPlayer.getCharacterEntity().getComponent(CurrencyStorageComponent.class);
-                    if (component != null) {
-                        return String.valueOf(component.amount);
-                    } else {
-                        return "0";
-                    }
-                }
-            });
-        }
+    public void setLabelText(int amount) {
+        label.setText(String.valueOf(amount));
     }
 }


### PR DESCRIPTION
Improvements for Terasology/MetalRenegades#30

 - Add command to give the player money
 - Make `UpdateWalletEvent` fire on the character entity instead of the wallet entity
 - Remove databinding for the wallet HUD. Manually changing label text now