### PR TITLE
Fix: Cost ui box component overlap with inventory ui box

### DIFF
--- a/assets/ui/walletHud.ui
+++ b/assets/ui/walletHud.ui
@@ -9,7 +9,7 @@
                     "height": 50,
                     "position-bottom": {},
                     "position-left": {
-                        "offset": 200
+                        "offset": 10
                     },
                     "width": 100
                 },


### PR DESCRIPTION
In the MR if we make the game window smaller vertically, then the cost ui box overlaps with the inventory. This PR will reduce the offset of that component to fix it.