### PR TITLE
fix: avoid NPE in WalletClientSystem by using a binding

### DIFF
--- a/src/main/java/org/terasology/economy/systems/WalletClientSystem.java
+++ b/src/main/java/org/terasology/economy/systems/WalletClientSystem.java
@@ -1,4 +1,4 @@
-// Copyright 2020 The Terasology Foundation
+// Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.economy.systems;
 
@@ -11,6 +11,8 @@ import org.terasology.engine.entitySystem.systems.RegisterMode;
 import org.terasology.engine.entitySystem.systems.RegisterSystem;
 import org.terasology.engine.registry.In;
 import org.terasology.engine.rendering.nui.NUIManager;
+import org.terasology.nui.databinding.Binding;
+import org.terasology.nui.databinding.DefaultBinding;
 
 /**
  * Manages the player's wallet UI.
@@ -21,14 +23,15 @@ public class WalletClientSystem extends BaseComponentSystem {
     @In
     private NUIManager nuiManager;
 
-    private WalletHud walletHud;
+    private Binding<String> walletBalance = new DefaultBinding<>("");
 
-    public void postBegin() {
-        walletHud = (WalletHud) nuiManager.getHUD().addHUDElement("walletHud");
+    public void preBegin() {
+        WalletHud walletHud = (WalletHud) nuiManager.getHUD().addHUDElement("walletHud");
+        walletHud.bind(walletBalance);
     }
 
     @ReceiveEvent
     public void onUpdateWallet(WalletUpdatedEvent event, EntityRef character) {
-        walletHud.setLabelText(event.amount);
+        walletBalance.set(String.valueOf(event.amount));
     }
 }

--- a/src/main/java/org/terasology/economy/ui/WalletHud.java
+++ b/src/main/java/org/terasology/economy/ui/WalletHud.java
@@ -1,8 +1,9 @@
-// Copyright 2020 The Terasology Foundation
+// Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.economy.ui;
 
 import org.terasology.engine.rendering.nui.layers.hud.CoreHudWidget;
+import org.terasology.nui.databinding.Binding;
 import org.terasology.nui.widgets.UILabel;
 
 /**
@@ -18,7 +19,7 @@ public class WalletHud extends CoreHudWidget {
         label.setText("0");
     }
 
-    public void setLabelText(int amount) {
-        label.setText(String.valueOf(amount));
+    public void bind(Binding<String> walletBalance) {
+        label.bindText(walletBalance);
     }
 }


### PR DESCRIPTION
`preBegin()`, despite its description, may be called only after the system already received events to its event handler. In that case, the `walletHud` was still null and causing an NPE in `onUpdateWallet`.

By using a binding this NPE is avoided. The binding value can be updated from the event handler even before it was hooked up with the HUD element.
